### PR TITLE
Correct the elemental grid check.

### DIFF
--- a/src/Menus/ElementalGrid/ElementalGridMenu.php
+++ b/src/Menus/ElementalGrid/ElementalGridMenu.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace WeDevelop\AdminToolbar\Menus\ElementalGrid;
 
 use Composer\InstalledVersions;
-use DNADesign\Elemental\Extensions\ElementalPageExtension as DNADesignElementalPageExtension;
-use DNADesign\Elemental\Models\BaseElement;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\Controller;
 use SilverStripe\ORM\ArrayList;
@@ -14,8 +12,6 @@ use SilverStripe\ORM\FieldType\DBHTMLText;
 use WeDevelop\AdminToolbar\Menus\ElementalGrid\MenuItems\ElementalGridMenuItem;
 use WeDevelop\AdminToolbar\Models\AdminToolbarMenu;
 use WeDevelop\AdminToolbar\Providers\AdminToolbarMenuProviderInterface;
-use WeDevelop\ElementalGrid\ElementalConfig;
-use WeDevelop\ElementalGrid\Extensions\ElementalPageExtension as WeDevelopElementalPageExtension;
 
 class ElementalGridMenu extends AdminToolbarMenu implements AdminToolbarMenuProviderInterface
 {
@@ -60,13 +56,13 @@ class ElementalGridMenu extends AdminToolbarMenu implements AdminToolbarMenuProv
         if (
             (
                 InstalledVersions::isInstalled('wedevelopnl/silverstripe-elemental-grid')
-                && $page->hasExtension(WeDevelopElementalPageExtension::class)
+                && $page->hasExtension(\WeDevelop\ElementalGrid\Extensions\ElementalPageExtension::class)
                 && $page->UseElementalGrid
             )
             ||
             (
                 InstalledVersions::isInstalled('dnadesign/silverstripe-elemental')
-                && $page->hasExtension(DNADesignElementalPageExtension::class)
+                && $page->hasExtension(\WeDevelop\ElementalGrid\Extensions\ElementalPageExtension::class)
             )
         ) {
             return $page->ElementalArea()?->Elements()?->count() > 0 ?? false;
@@ -75,9 +71,9 @@ class ElementalGridMenu extends AdminToolbarMenu implements AdminToolbarMenuProv
         return false;
     }
 
-    public function getElementalConfig(): ElementalConfig
+    public function getElementalConfig(): \WeDevelop\ElementalGrid\ElementalConfig
     {
-        return new ElementalConfig();
+        return new \WeDevelop\ElementalGrid\ElementalConfig();
     }
 
     public function getItems(): ArrayList
@@ -88,11 +84,11 @@ class ElementalGridMenu extends AdminToolbarMenu implements AdminToolbarMenuProv
 
         $elements = $page?->ElementalArea?->Elements();
 
-        /** @var BaseElement $element */
+        /** @var \DNADesign\Elemental\Models\BaseElement $element */
         foreach ($elements as $element) {
             $item = ElementalGridMenuItem::create();
 
-            $sizeKey = sprintf('Size%s', ElementalConfig::getDefaultViewport());
+            $sizeKey = sprintf('Size%s', \WeDevelop\ElementalGrid\ElementalConfig::getDefaultViewport());
             $element->Title = $element->getTitle() ?? 'Untitled ' . $element->i18n_singular_name();
             $element->Size = $element->$sizeKey ?: 12;
             $item->setElement($element);

--- a/src/Menus/ElementalGrid/ElementalGridMenu.php
+++ b/src/Menus/ElementalGrid/ElementalGridMenu.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace WeDevelop\AdminToolbar\Menus\ElementalGrid;
 
 use Composer\InstalledVersions;
+use DNADesign\Elemental\Extensions\ElementalPageExtension as DNADesignElementalPageExtension;
 use DNADesign\Elemental\Models\BaseElement;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\Controller;
@@ -14,14 +15,13 @@ use WeDevelop\AdminToolbar\Menus\ElementalGrid\MenuItems\ElementalGridMenuItem;
 use WeDevelop\AdminToolbar\Models\AdminToolbarMenu;
 use WeDevelop\AdminToolbar\Providers\AdminToolbarMenuProviderInterface;
 use WeDevelop\ElementalGrid\ElementalConfig;
+use WeDevelop\ElementalGrid\Extensions\ElementalPageExtension as WeDevelopElementalPageExtension;
 
 class ElementalGridMenu extends AdminToolbarMenu implements AdminToolbarMenuProviderInterface
 {
     private int $order = 2;
 
     public const MENU_NAME = 'ElementalGrid';
-
-    private const ELEMENTAL_GRID_PAGE_EXTENSION_CLASS = \DNADesign\Elemental\Extensions\ElementalPageExtension::class;
 
     public function getName(): string
     {
@@ -57,7 +57,22 @@ class ElementalGridMenu extends AdminToolbarMenu implements AdminToolbarMenuProv
         /** @var SiteTree $page */
         $page = Controller::curr()->data();
 
-        return InstalledVersions::isInstalled('dnadesign/silverstripe-elemental') && $page->hasExtension(self::ELEMENTAL_GRID_PAGE_EXTENSION_CLASS) && $page->UseElementalGrid && $page->ElementalArea()->Elements()->count() > 0;
+        if (
+            (
+                InstalledVersions::isInstalled('wedevelopnl/silverstripe-elemental-grid')
+                && $page->hasExtension(WeDevelopElementalPageExtension::class)
+                && $page->UseElementalGrid
+            )
+            ||
+            (
+                InstalledVersions::isInstalled('dnadesign/silverstripe-elemental')
+                && $page->hasExtension(DNADesignElementalPageExtension::class)
+            )
+        ) {
+            return $page->ElementalArea()?->Elements()?->count() > 0 ?? false;
+        }
+
+        return false;
     }
 
     public function getElementalConfig(): ElementalConfig


### PR DESCRIPTION
Correcly account for the difference in behaviour between the DNAdesign and WeDevelop grid page extensions.